### PR TITLE
Fix deprecated methods in `office2hashcat.py` to work with Python 3.9+

### DIFF
--- a/scrapers/office2hashcat.py
+++ b/scrapers/office2hashcat.py
@@ -2655,7 +2655,7 @@ def process_new_office(filename):
         tree = ElementTree()
         tree.parse(data)
 
-        for node in tree.getiterator('{http://schemas.microsoft.com/office/2006/keyEncryptor/password}encryptedKey'):
+        for node in tree.iter('{http://schemas.microsoft.com/office/2006/keyEncryptor/password}encryptedKey'):
             spinCount = node.attrib.get("spinCount")
             assert(spinCount)
             saltSize = node.attrib.get("saltSize")
@@ -2682,12 +2682,12 @@ def process_new_office(filename):
             assert(saltValue)
             encryptedVerifierHashInput = node.attrib.get("encryptedVerifierHashInput")
             encryptedVerifierHashValue = node.attrib.get("encryptedVerifierHashValue")
-            encryptedVerifierHashValue = binascii.hexlify(base64.decodestring(encryptedVerifierHashValue.encode()))
+            encryptedVerifierHashValue = binascii.hexlify(base64.decodebytes(encryptedVerifierHashValue.encode()))
 
             sys.stdout.write("$office$*%d*%d*%d*%d*%s*%s*%s\n" % \
                 (version, int(spinCount), int(keyBits), int(saltSize),
-                binascii.hexlify(base64.decodestring(saltValue.encode())).decode("ascii"),
-                binascii.hexlify(base64.decodestring(encryptedVerifierHashInput.encode())).decode("ascii"),
+                binascii.hexlify(base64.decodebytes(saltValue.encode())).decode("ascii"),
+                binascii.hexlify(base64.decodebytes(encryptedVerifierHashInput.encode())).decode("ascii"),
                 encryptedVerifierHashValue[0:64].decode("ascii")))
             return 0
     else:
@@ -2760,12 +2760,12 @@ def xml_metadata_parser(data, filename):
         assert(saltValue)
         encryptedVerifierHashInput = node.attrib.get("encryptedVerifierHashInput")
         encryptedVerifierHashValue = node.attrib.get("encryptedVerifierHashValue")
-        encryptedVerifierHashValue = binascii.hexlify(base64.decodestring(encryptedVerifierHashValue.encode()))
+        encryptedVerifierHashValue = binascii.hexlify(base64.decodebytes(encryptedVerifierHashValue.encode()))
 
         sys.stdout.write("$office$*%d*%d*%d*%d*%s*%s*%s\n" % \
             (version, int(spinCount), int(keyBits), int(saltSize),
-            binascii.hexlify(base64.decodestring(saltValue.encode())).decode("ascii"),
-            binascii.hexlify(base64.decodestring(encryptedVerifierHashInput.encode())).decode("ascii"),
+            binascii.hexlify(base64.decodebytes(saltValue.encode())).decode("ascii"),
+            binascii.hexlify(base64.decodebytes(encryptedVerifierHashInput.encode())).decode("ascii"),
             encryptedVerifierHashValue[0:64].decode("ascii")))
         return 0
 


### PR DESCRIPTION
## Problem

- `office2hashcat.py` no longer works with Python 3.9+.

## Cause

The following methods have been deprecated and removed.

- `ElementTree.getiterator()` has been removed since Python 3.9. (cf. <https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator> )
- `Base64.decodestring()` has been removed since Python 3.9. (cf. <https://docs.python.org/3.8/library/base64.html#base64.decodestring>)

## Modification

- Fix `ElementTree.getiterator()` to `ElementTree.iter()`.
- Fix `Base64.decodestring()` to `Base64.decodebytes()`.

This PR resolves the issue #5 .
