### PR TITLE
Remove spurious b'…' from pdf2hashcat.py hashes

### DIFF
--- a/scrapers/pdf2hashcat.py
+++ b/scrapers/pdf2hashcat.py
@@ -112,7 +112,7 @@ class PdfParser:
         output = '$pdf$'+v.decode('ascii')+'*'+r.decode('ascii')+'*'+length.decode('ascii')+'*'
         output += p.decode('ascii')+'*'+meta+'*'
         output += str(int(len(i_d)/2))+'*'+i_d.decode('ascii')+'*'+passwords
-        sys.stdout.write("%s\n" % output.encode('UTF-8'))
+        sys.stdout.write(output+"\n")
 
     def get_passwords_for_JtR(self, encryption_dictionary):
         output = ""


### PR DESCRIPTION
Fix Issue #9 by getting rid of incorrect encoding of str object "output" into a bytes object, and instead writing the str.